### PR TITLE
Evals: Add llm guardrails

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -72,6 +72,7 @@ TASK_NAME_TO_CLASS = {
     "ultrafeedback": misc_jobs_module.UltrafeedbackJob,
     "mlmmlu_amateur_semipro": misc_jobs_module.MLMMLUAmateurSemipro,
     "mlmmlu_rookie_reserve": misc_jobs_module.MLMMLUReserveRookie,
+    "llm_guardrails": misc_jobs_module.LLMGuardrails,
 }
 
 GLUE_TASKS = {"mnli", "rte", "mrpc", "qnli", "qqp", "sst2", "stsb", "cola"}

--- a/eval.py
+++ b/eval.py
@@ -73,6 +73,8 @@ TASK_NAME_TO_CLASS = {
     "mlmmlu_amateur_semipro": misc_jobs_module.MLMMLUAmateurSemipro,
     "mlmmlu_rookie_reserve": misc_jobs_module.MLMMLUReserveRookie,
     "llm_guardrails": misc_jobs_module.LLMGuardrails,
+    "beavertails": misc_jobs_module.BeaverTails,
+    "wildjailbreak_original": misc_jobs_module.WildJailBreakOriginal,
 }
 
 GLUE_TASKS = {"mnli", "rte", "mrpc", "qnli", "qqp", "sst2", "stsb", "cola"}

--- a/generate_eval_config.py
+++ b/generate_eval_config.py
@@ -420,6 +420,14 @@ def main(
 
     new_config["tasks"] = tasks_dict
 
+    # Extract actual values from dict-wrapped configs
+    if isinstance(new_config.get("base_run_name"), dict) and "value" in new_config["base_run_name"]:
+        new_config["base_run_name"] = new_config["base_run_name"]["value"]
+    if isinstance(new_config.get("precision"), dict) and "value" in new_config["precision"]:
+        new_config["precision"] = new_config["precision"]["value"]
+    if isinstance(new_config.get("tokenizer_name"), dict) and "value" in new_config["tokenizer_name"]:
+        new_config["tokenizer_name"] = new_config["tokenizer_name"]["value"]
+
     # Write the new configuration to a YAML file
     output_filename = output_dir / f"{ckpt_id}_evaluation.yaml"
     with output_filename.open("w") as file:

--- a/generate_eval_config.py
+++ b/generate_eval_config.py
@@ -407,6 +407,10 @@ def main(
             task_config["seeds"] = seeds[:1]
             task_config["trainer_kwargs"] = {"save_num_checkpoints_to_keep": 0}
 
+        elif task_name == "llm_guardrails":
+            task_config["seeds"] = seeds[:3]
+            task_config["trainer_kwargs"] = {"save_num_checkpoints_to_keep": 0}
+
         else:
             print(
                 f"Warning: Task '{task_name}' doesn't have eval_config defaults. Using task defaults with three seeds."

--- a/run_evals.py
+++ b/run_evals.py
@@ -486,6 +486,7 @@ def download_datasets(tasks: List[TaskName], msg_queue):  # type: ignore
             "mlmmlu_rookie_reserve": [["answerdotai/MLMMLU", "Rookie"], ["answerdotai/MLMMLU", "Reserve"]],
             "eurlex": [["coastalcph/lex_glue", "eurlex"]],
             "ultrafeedback": [["rbiswasfc/ultrafeedback-binary-classification"]],
+            "llm_guardrails": [["ModernBERT/llm_guardrails", "wildjailbreak"], ["ModernBERT/llm_guardrails", "alert_vanilla"], ["ModernBERT/llm_guardrails", "alert_adversarial"]],
         }
 
         for task in tasks:

--- a/scripts/prepare_jailbreaks_data.py
+++ b/scripts/prepare_jailbreaks_data.py
@@ -1,0 +1,326 @@
+from datasets import load_dataset,concatenate_datasets, DatasetDict
+import argparse
+import random
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--target_repo", type=str, default=None)
+parser.add_argument("--private_repo", action="store_true", default=False)
+args = parser.parse_args()
+BINARIZE_LABELS = True
+TARGET_HF_REPO = args.target_repo
+PRIVATE_REPO = args.private_repo
+
+
+
+def prep_jailbreak_and_alert():
+    jailbreak_train = load_dataset("allenai/wildjailbreak", 'train', delimiter="\t", keep_default_na=False,)
+
+    # Load the WildJailbreak evaluation set
+    jailbreak_eval = load_dataset("allenai/wildjailbreak", "eval", split='train', delimiter="\t", keep_default_na=False,N)
+
+
+    alert_vanilla = load_dataset("Babelscape/ALERT", "alert")
+    alert_adversarial = load_dataset("Babelscape/ALERT", "alert_adversarial")
+
+    def is_valid_vanilla_example(example):
+        # Check if the example meets the criteria for inclusion
+        return (
+            example['vanilla'] and
+            len(example['vanilla'].strip()) > 0 and
+            'vanilla' in example['data_type']
+        )
+
+    def is_valid_adversarial_example(example):
+        return (
+            example['adversarial'] and
+            len(example['adversarial'].strip()) > 0 and
+            'adversarial' in example['data_type']
+        )
+
+    def map_to_vanilla_example(example):
+        # Extract only the required fields
+        return {
+            'text': example['vanilla'],
+            'label': example['data_type']
+        }
+
+    def map_to_adversarial_example(example):
+        return {
+            'text': example['adversarial'],
+            'label': example['data_type']
+        }
+
+    # Filter and process the dataset
+    def process_dataset(dataset, valid_fn, map_fn, is_eval: bool = False):
+        # Step 1: Filter out invalid examples
+        filtered_dataset = dataset.filter(valid_fn)
+        
+        # Step 2: Map to the desired structure
+        processed_dataset = filtered_dataset.map(
+            map_fn,
+            remove_columns=['vanilla', 'adversarial', 'completion', 'data_type'] if not is_eval else ['adversarial', 'data_type'],  # Drop unnecessary columns
+        )
+        
+        return processed_dataset
+
+    vanilla_train_pool = process_dataset(jailbreak_train['train'], is_valid_vanilla_example, map_to_vanilla_example)
+    adversarial_train_pool = process_dataset(jailbreak_train['train'], is_valid_adversarial_example, map_to_adversarial_example)
+
+
+    wildjailbreak_test = process_dataset(jailbreak_eval, is_valid_adversarial_example, map_to_adversarial_example, is_eval=True)
+
+    alert_vanilla = load_dataset("Babelscape/ALERT", "alert")
+    alert_adversarial = load_dataset("Babelscape/ALERT", "alert_adversarial")
+
+
+    alert_vanilla = alert_vanilla.rename_column("prompt", "text")
+
+    alert_adversarial = alert_adversarial.rename_column("prompt", "text")
+
+
+    # Get unique categories and their counts for vanilla dataset
+    vanilla_categories = alert_vanilla["test"].unique("category")
+    vanilla_category_counts = {cat: len(alert_vanilla["test"].filter(lambda x: x["category"] == cat)) for cat in vanilla_categories}
+
+    # Initialize empty lists for train and test indices
+    vanilla_train_indices = []
+    vanilla_test_indices = []
+
+    # Split each category roughly in half while maintaining proportions
+    for category in vanilla_categories:
+        category_indices = [i for i, x in enumerate(alert_vanilla["test"]) if x["category"] == category]
+        half_size = len(category_indices) // 2
+        
+        # Shuffle indices for this category
+        shuffled_indices = category_indices.copy()
+        random.seed(42)
+        random.shuffle(shuffled_indices)
+        
+        vanilla_train_indices.extend(shuffled_indices[:half_size])
+        vanilla_test_indices.extend(shuffled_indices[half_size:half_size*2])
+
+    # Create stratified train/test splits for vanilla
+    alert_vanilla_train = alert_vanilla["test"].select(vanilla_train_indices)
+    alert_vanilla_test = alert_vanilla["test"].select(vanilla_test_indices)
+
+    # Remove any overlapping examples between train and test based on text
+    alert_vanilla_test_texts = set(alert_vanilla_test["text"])
+    alert_vanilla_train = alert_vanilla_train.filter(lambda x: x["text"] not in alert_vanilla_test_texts)
+
+    # Get matching amount of harmful examples from wildjailbreak for training
+    wildjailbreak_harmful = vanilla_train_pool.filter(lambda x: x["label"] == "vanilla_harmful").shuffle(seed=42)
+    wildjailbreak_harmful_sample = wildjailbreak_harmful.select(range(len(alert_vanilla_train)))
+
+    # Get matching amount of benign examples from wildjailbreak for training
+    wildjailbreak_benign = vanilla_train_pool.filter(lambda x: x["label"] == "vanilla_benign").shuffle(seed=42)
+    wildjailbreak_benign_sample = wildjailbreak_benign.select(range(len(alert_vanilla_train) * 2))
+
+    # Get benign examples for alert_vanilla_test from remaining wildjailbreak benign examples
+    remaining_wildjailbreak_benign = wildjailbreak_benign.select(range(len(alert_vanilla_train) * 2, len(wildjailbreak_benign)))
+    alert_vanilla_test_benign = remaining_wildjailbreak_benign.select(range(len(alert_vanilla_test)))
+
+    # Do the same stratified split for adversarial dataset
+    adversarial_categories = alert_adversarial["test"].unique("category")
+    adversarial_category_counts = {cat: len(alert_adversarial["test"].filter(lambda x: x["category"] == cat)) for cat in adversarial_categories}
+
+    adversarial_train_indices = []
+    adversarial_test_indices = []
+
+    for category in adversarial_categories:
+        category_indices = [i for i, x in enumerate(alert_adversarial["test"]) if x["category"] == category]
+        half_size = len(category_indices) // 2
+        
+        shuffled_indices = category_indices.copy()
+        random.seed(42)
+        random.shuffle(shuffled_indices)
+        
+        adversarial_train_indices.extend(shuffled_indices[:half_size])
+        adversarial_test_indices.extend(shuffled_indices[half_size:half_size*2])
+
+    # Create stratified train/test splits for adversarial
+    alert_adversarial_train = alert_adversarial["test"].select(adversarial_train_indices)
+    alert_adversarial_test = alert_adversarial["test"].select(adversarial_test_indices)
+
+    # Remove any overlapping examples between train and test based on text
+    alert_adversarial_test_texts = set(alert_adversarial_test["text"])
+    alert_adversarial_train = alert_adversarial_train.filter(lambda x: x["text"] not in alert_adversarial_test_texts)
+
+    # Get matching amount of harmful examples from wildjailbreak for training
+    wildjailbreak_adv_harmful = adversarial_train_pool.filter(lambda x: x["label"] == "adversarial_harmful").shuffle(seed=42)
+    wildjailbreak_adv_harmful_sample = wildjailbreak_adv_harmful.select(range(len(alert_adversarial_train)))
+
+    # Get matching amount of benign examples from wildjailbreak for training
+    wildjailbreak_adv_benign = adversarial_train_pool.filter(lambda x: x["label"] == "adversarial_benign").shuffle(seed=42)
+    wildjailbreak_adv_benign_sample = wildjailbreak_adv_benign.select(range(len(alert_adversarial_train) * 2))
+
+    # Get benign examples for alert_adversarial_test from remaining wildjailbreak adversarial benign examples
+    remaining_wildjailbreak_adv_benign = wildjailbreak_adv_benign.select(range(len(alert_adversarial_train) * 2, len(wildjailbreak_adv_benign)))
+    alert_adversarial_test_benign = remaining_wildjailbreak_adv_benign.select(range(len(alert_adversarial_test)))
+
+    # Get benign examples for wildjailbreak test from remaining benign examples
+    remaining_vanilla_benign = wildjailbreak_benign.select(range(len(alert_vanilla_train) * 2 + len(alert_vanilla_test), len(wildjailbreak_benign)))
+    remaining_adv_benign = wildjailbreak_adv_benign.select(range(len(alert_adversarial_train) * 2 + len(alert_adversarial_test), len(wildjailbreak_adv_benign)))
+
+    wildjailbreak_test_vanilla_benign = remaining_vanilla_benign.select(range(len(wildjailbreak_test) // 2))
+    wildjailbreak_test_adv_benign = remaining_adv_benign.select(range(len(wildjailbreak_test) // 2))
+
+    # Combine harmful and benign examples for test sets
+    alert_vanilla_test = concatenate_datasets([alert_vanilla_test, alert_vanilla_test_benign])
+    alert_adversarial_test = concatenate_datasets([alert_adversarial_test, alert_adversarial_test_benign])
+    wildjailbreak_test = concatenate_datasets([wildjailbreak_test, wildjailbreak_test_vanilla_benign, wildjailbreak_test_adv_benign])
+
+
+    print("Alert Vanilla Train Size:", len(alert_vanilla_train))
+    print("Alert Vanilla Test Size:", len(alert_vanilla_test))
+    print("WildJailbreak Harmful Sample Size:", len(wildjailbreak_harmful_sample))
+    print("WildJailbreak Benign Sample Size:", len(wildjailbreak_benign_sample))
+
+    print("\nAlert Adversarial Train Size:", len(alert_adversarial_train))
+    print("Alert Adversarial Test Size:", len(alert_adversarial_test))
+    print("WildJailbreak Adversarial Harmful Sample Size:", len(wildjailbreak_adv_harmful_sample))
+    print("WildJailbreak Adversarial Benign Sample Size:", len(wildjailbreak_adv_benign_sample))
+
+
+    # Rename columns in ALERT datasets to match WildJailbreak format
+    # Update labels for ALERT vanilla datasets
+    alert_vanilla_train = alert_vanilla_train.map(lambda x: {"label": "vanilla_harmful"})
+    alert_vanilla_test = alert_vanilla_test.map(lambda x: {"label": "vanilla_harmful"})
+
+    # Update labels for ALERT adversarial datasets 
+    alert_adversarial_train = alert_adversarial_train.map(lambda x: {"label": "adversarial_harmful"})
+    alert_adversarial_test = alert_adversarial_test.map(lambda x: {"label": "adversarial_harmful"})
+
+    # Print unique labels for each dataset
+    print("Alert Vanilla Train Labels:", set(alert_vanilla_train["label"]))
+    print("Alert Vanilla Test Labels:", set(alert_vanilla_test["label"]))
+    print("WildJailbreak Harmful Sample Labels:", set(wildjailbreak_harmful_sample["label"]))
+    print("WildJailbreak Benign Sample Labels:", set(wildjailbreak_benign_sample["label"]))
+
+    print("\nAlert Adversarial Train Labels:", set(alert_adversarial_train["label"]))
+    print("Alert Adversarial Test Labels:", set(alert_adversarial_test["label"])) 
+    print("WildJailbreak Adversarial Harmful Sample Labels:", set(wildjailbreak_adv_harmful_sample["label"]))
+    print("WildJailbreak Adversarial Benign Sample Labels:", set(wildjailbreak_adv_benign_sample["label"]))
+    train_dataset = DatasetDict({
+        "train": concatenate_datasets([
+            alert_vanilla_train,
+            alert_adversarial_train,
+            wildjailbreak_harmful_sample,
+            wildjailbreak_benign_sample,
+            wildjailbreak_adv_harmful_sample, 
+            wildjailbreak_adv_benign_sample
+        ])
+    })
+
+    # Create test datasets in separate subsets
+    test_datasets = DatasetDict({
+        "wildjailbreak": DatasetDict({
+            "test": wildjailbreak_test
+        }),
+        "alert_vanilla": DatasetDict({
+            "test": alert_vanilla_test
+        }),
+        "alert_adversarial": DatasetDict({
+            "test": alert_adversarial_test
+        })
+    })
+
+    print("\nTrain dataset size:", len(train_dataset["train"]))
+    print("WildJailbreak test size:", len(test_datasets["wildjailbreak"]["test"]))
+    print("ALERT vanilla test size:", len(test_datasets["alert_vanilla"]["test"])) 
+    print("ALERT adversarial test size:", len(test_datasets["alert_adversarial"]["test"]))
+
+    # Combine all datasets into one for upload
+    train_ds  = DatasetDict({
+        "train": train_dataset["train"].remove_columns(["id", "attack_type"]),
+    })
+    test_wildjailbreak_ds = DatasetDict({
+        "test": test_datasets["wildjailbreak"]["test"]
+    })
+    test_alert_vanilla_ds = DatasetDict({
+        "test": test_datasets["alert_vanilla"]["test"].remove_columns(["id"])
+    })
+    test_alert_adversarial_ds = DatasetDict({
+        "test": test_datasets["alert_adversarial"]["test"].remove_columns(["id", "attack_type"])
+    })
+
+
+    if BINARIZE_LABELS:
+        def map_label(example):
+            label = example["label"]
+            return {"label": "harmful" if "harmful" in label.lower() else "benign"}
+
+        train_ds["train"] = train_ds["train"].map(map_label)
+        test_wildjailbreak_ds["test"] = test_wildjailbreak_ds["test"].map(map_label) 
+        test_alert_vanilla_ds["test"] = test_alert_vanilla_ds["test"].map(map_label)
+        test_alert_adversarial_ds["test"] = test_alert_adversarial_ds["test"].map(map_label)
+        class2id = {}
+        class2id['benign'] = 0
+        class2id['harmful'] = 1
+
+    else:
+        train_classes = sorted(list(set(train_dataset["train"]["label"])))
+        class2id = {class_: id for id, class_ in enumerate(train_classes)}
+
+
+
+    train_ds["train"] = train_ds["train"].map(lambda x: {"label": class2id[x["label"]]})
+    test_wildjailbreak_ds["test"] = test_wildjailbreak_ds["test"].map(lambda x: {"label": class2id[x["label"]]})
+    test_alert_vanilla_ds["test"] = test_alert_vanilla_ds["test"].map(lambda x: {"label": class2id[x["label"]]})
+    test_alert_adversarial_ds["test"] = test_alert_adversarial_ds["test"].map(lambda x: {"label": class2id[x["label"]]})
+
+
+    # Clean up text formatting in all datasets
+    def clean_text(example):
+        text = example["text"]
+        text = text.replace("\n", " ")
+        text = text.replace("### Instruction:", "")
+        text = text.replace("### Response:", "") 
+        text = text.strip()
+        return {"text": text}
+
+    train_ds["train"] = train_ds["train"].map(clean_text)
+    test_wildjailbreak_ds["test"] = test_wildjailbreak_ds["test"].map(clean_text)
+    test_alert_vanilla_ds["test"] = test_alert_vanilla_ds["test"].map(clean_text)
+    test_alert_adversarial_ds["test"] = test_alert_adversarial_ds["test"].map(clean_text)
+
+    # Shuffle all datasets with seed 42
+    train_ds["train"] = train_ds["train"].shuffle(seed=42)
+    test_wildjailbreak_ds["test"] = test_wildjailbreak_ds["test"].shuffle(seed=42)
+    test_alert_vanilla_ds["test"] = test_alert_vanilla_ds["test"].shuffle(seed=42)
+    test_alert_adversarial_ds["test"] = test_alert_adversarial_ds["test"].shuffle(seed=42)
+
+    # Remove category column if it exists
+    if "category" in train_ds["train"].features:
+        train_ds["train"] = train_ds["train"].remove_columns("category")
+    if "category" in test_wildjailbreak_ds["test"].features:
+        test_wildjailbreak_ds["test"] = test_wildjailbreak_ds["test"].remove_columns("category") 
+    if "category" in test_alert_vanilla_ds["test"].features:
+        test_alert_vanilla_ds["test"] = test_alert_vanilla_ds["test"].remove_columns("category")
+    if "category" in test_alert_adversarial_ds["test"].features:
+        test_alert_adversarial_ds["test"] = test_alert_adversarial_ds["test"].remove_columns("category")
+
+
+    # Push to the Hub
+    train_ds.push_to_hub(TARGET_HF_REPO, 'train', private=PRIVATE_REPO)
+    test_wildjailbreak_ds.push_to_hub(TARGET_HF_REPO, 'test_wildjailbreak', private=PRIVATE_REPO)
+    test_alert_vanilla_ds.push_to_hub(TARGET_HF_REPO, 'test_alert_vanilla', private=PRIVATE_REPO)
+    test_alert_adversarial_ds.push_to_hub(TARGET_HF_REPO, 'test_alert_adversarial', private=PRIVATE_REPO)
+
+
+def beaver_tails():
+    beaver_tails = load_dataset("PKU-Alignment/BeaverTails", split='330k_test')
+    def process_beaver_tails(example):
+        return {
+            "text": example["prompt"],
+            "label": int(not example["is_safe"])  # Convert True->0, False->1
+        }
+
+    beaver_tails = beaver_tails.map(process_beaver_tails, remove_columns=["prompt", "response", "category", "is_safe"])
+    test_beaver_tails_ds = DatasetDict({
+        "test": beaver_tails
+    })
+    test_beaver_tails_ds.push_to_hub(TARGET_HF_REPO, 'test_beaver_tails', private=PRIVATE_REPO)
+
+if __name__ == "__main__":
+    prep_jailbreak_and_alert()
+    beaver_tails()

--- a/src/evals/data.py
+++ b/src/evals/data.py
@@ -92,6 +92,8 @@ def create_eval_dataset(
         download_config=download_config,
     )
 
+    print(dataset)
+
     log.info(f"Starting tokenization by preprocessing over {num_workers} threads!")
     text_column_names = task_column_names[task]
 
@@ -194,5 +196,5 @@ def create_guardrails_dataset(**kwargs):
     return create_eval_dataset(
         **kwargs,
         dataset_name="ModernBERT/llm_guardrails",
-        task_column_names={"ModernBERT/llm_guardrails": ("text", "label")},
+        task_column_names={"ModernBERT/llm_guardrails": ("text", None)},
     )

--- a/src/evals/data.py
+++ b/src/evals/data.py
@@ -182,3 +182,17 @@ def create_mlmmlu_dataset(**kwargs):
             **kwargs,
         )
 
+def create_ultrafeedback_dataset(**kwargs):
+    return create_eval_dataset(
+        **kwargs,
+        dataset_name="rbiswasfc/ultrafeedback-binary-classification",
+        dataset_subset="",
+        task_column_names={"rbiswasfc/ultrafeedback-binary-classification": ("prompt", "response_a", "response_b")},
+    )
+
+def create_guardrails_dataset(**kwargs):
+    return create_eval_dataset(
+        **kwargs,
+        dataset_name="ModernBERT/llm_guardrails",
+        task_column_names={"ModernBERT/llm_guardrails": ("text", "label")},
+    )

--- a/src/evals/data.py
+++ b/src/evals/data.py
@@ -92,8 +92,6 @@ def create_eval_dataset(
         download_config=download_config,
     )
 
-    print(dataset)
-
     log.info(f"Starting tokenization by preprocessing over {num_workers} threads!")
     text_column_names = task_column_names[task]
 

--- a/wandb_log_live_eval.py
+++ b/wandb_log_live_eval.py
@@ -118,6 +118,14 @@ def main():
             "metrics/alert_adversarial/MulticlassAccuracy",
             "metrics/beavertails/MulticlassAccuracy",
         ],
+        "wildjailbreak_original": [
+            "metrics/wildjailbreak/MulticlassAccuracy",
+            "metrics/beavertails/BinaryF1Score",
+        ],
+        "beavertails": [
+            "metrics/beavertails/MulticlassAccuracy",
+            "metrics/beavertails/BinaryF1Score",
+        ],
     }
 
     args.metric2num_seeds = {
@@ -128,9 +136,11 @@ def main():
         "metrics/superglue_wic/MulticlassAccuracy": 3,
         "metrics/superglue_boolq/MulticlassAccuracy": 3,
         "metrics/wildjailbreak/MulticlassAccuracy": 3,
+        "metrics/wildjailbreak/BinaryF1Score": 3,
         "metrics/alert_vanilla/MulticlassAccuracy": 3,
         "metrics/alert_adversarial/MulticlassAccuracy": 3,
         "metrics/beavertails/MulticlassAccuracy": 3,
+        "metrics/beavertails/BinaryF1Score": 3,
         "metrics/long_context_ultrafeedback/UltrafeedbackAUROC": 2,
     }
 

--- a/wandb_log_live_eval.py
+++ b/wandb_log_live_eval.py
@@ -112,6 +112,11 @@ def main():
         ],
         "wic": ["metrics/superglue_wic/MulticlassAccuracy"],
         "boolq": ["metrics/superglue_boolq/MulticlassAccuracy"],
+        "llm_guardrails": [
+            "metrics/wildjailbreak/MulticlassAccuracy",
+            "metrics/alert_vanilla/MulticlassAccuracy",
+            "metrics/alert_adversarial/MulticlassAccuracy",
+        ],
     }
 
     args.metric2num_seeds = {
@@ -121,6 +126,9 @@ def main():
         "metrics/mlmmlu_reserve/MulticlassAccuracy": 3,
         "metrics/superglue_wic/MulticlassAccuracy": 3,
         "metrics/superglue_boolq/MulticlassAccuracy": 3,
+        "metrics/wildjailbreak/MulticlassAccuracy": 3,
+        "metrics/alert_vanilla/MulticlassAccuracy": 3,
+        "metrics/alert_adversarial/MulticlassAccuracy": 3,
         "metrics/long_context_ultrafeedback/UltrafeedbackAUROC": 2,
     }
 
@@ -131,6 +139,9 @@ def main():
         # "metrics/mlmmlu_reserve/MulticlassAccuracy",
         "metrics/superglue_wic/MulticlassAccuracy",
         "metrics/superglue_boolq/MulticlassAccuracy",
+        "metrics/wildjailbreak/MulticlassAccuracy",
+        "metrics/alert_vanilla/MulticlassAccuracy",
+        "metrics/alert_adversarial/MulticlassAccuracy",
     ]
 
     if args.init_meta:

--- a/wandb_log_live_eval.py
+++ b/wandb_log_live_eval.py
@@ -116,6 +116,7 @@ def main():
             "metrics/wildjailbreak/MulticlassAccuracy",
             "metrics/alert_vanilla/MulticlassAccuracy",
             "metrics/alert_adversarial/MulticlassAccuracy",
+            "metrics/beavertails/MulticlassAccuracy",
         ],
     }
 
@@ -129,6 +130,7 @@ def main():
         "metrics/wildjailbreak/MulticlassAccuracy": 3,
         "metrics/alert_vanilla/MulticlassAccuracy": 3,
         "metrics/alert_adversarial/MulticlassAccuracy": 3,
+        "metrics/beavertails/MulticlassAccuracy": 3,
         "metrics/long_context_ultrafeedback/UltrafeedbackAUROC": 2,
     }
 
@@ -142,6 +144,7 @@ def main():
         "metrics/wildjailbreak/MulticlassAccuracy",
         "metrics/alert_vanilla/MulticlassAccuracy",
         "metrics/alert_adversarial/MulticlassAccuracy",
+        "metrics/beavertails/MulticlassAccuracy",
     ]
 
     if args.init_meta:


### PR DESCRIPTION
~~_EDIT: The script should appear at some point... Github seems to be having issue with my push at the moment and is returning server errors 🤔_ ~~ It's there!

Adding LLM guardrails evals, as well as the script used to generate them. Might be due further modification to ensure it's neither too easy nor too hard, but there is signal (pointing towards too easy).

In order to run the dataset, you must have an HF_Token set, with access to our development org.

Definitions:
- Harmful implies that the content is problematic in some way, for any reason (insults, violence, pornography, warfare, etc...)
- Benign on the other hand is content which does not need moderated.
- Vanilla means that the prompt is relatively straightforward, and does not use an adversarial method to bypass guardrails put on LLMs.
- Adversarial means that the prompt is attempting to bypass an LLM's moderation system.

We use three datasets:
- AllenAI's [wildjailbreak](https://huggingface.co/datasets/allenai/wildjailbreak). It contains a very large number of Vanilla Benign, Vanilla Harmful, Adversarial Benign, and Adversarial Harmful content. The train set has 200k+ examples of all, and the built-in eval set has only harmful examples.
- Babelscape's ALERT. It contains 15k examples of Vanilla Harmful (of various kinds) and 30k examples of Adversarial Harmful (of various kinds).
- Beavertails's 30k test set of vanilla prompts, both benign and harmful.

The dataset currently pushed has 4 evaluation sets, and a train set, which are constructed as follows:
- The task is binary classification, between harmful and benign.
- We don't consider the differences between types of harmful content, nor between adversarial and vanilla in this version. If the evals are far too easy or we feel the paper needs it, we'll include the fine-grained categories in a subsequent PR.
- ALERT vanilla and ALERT adversarial are both split in half (7.5k train/7.5k test for vanilla, 15k/15k for adversarial).
- The train set consists of ~90k examples. 22.5k are form ALERT, 22.5k are harmful examples from wildjailbreak, the remaining 45k are benign examples (stratified btwn adversarial and vanilla based on the ALERT distribution).
- The wildjailbreak evaluation set are the 2.2k harmful examples from the original dataset's eval set and a randomly sampled 2.2k benign examples.
- The beavertails evaluation set is treated as out-of-domain and kept as-is from the original dataset. We do not use its trainset.


(Note: I pushed this to iterate quickly -- it's very possible that a follow-up PR tomorrow will shuffle the datasets a bit, potentially adding OpenAI's moderation dataset and beavertails trainset and removing ALERT. Good starting point anyhow)