### PR TITLE
Wrap training scripts in def main(), update default model name

### DIFF
--- a/examples/evaluate_pylate.py
+++ b/examples/evaluate_pylate.py
@@ -22,7 +22,7 @@ def fetch_most_recent_checkpoint(model_path: str):
 
 
 eval_datasets = ["fiqa", "scifact", "nfcorpus", "trec-covid"]
-model_name = "ModernBERT/bert24-base-v2-2ep-decay_100B-0.08-lr"
+model_name = "answerdotai/ModernBERT-base"
 model_shortname = model_name.split("/")[-1]
 lr = 8e-5
 model_results = defaultdict(dict)
@@ -31,7 +31,6 @@ output_dir = f"output/{model_shortname}/{run_name}"
 model = models.ColBERT(
     model_name_or_path=f"{output_dir}/final",
     document_length=510,
-    trust_remote_code=True,
 )
 for dataset in eval_datasets:
     for eval_dataset in eval_datasets:

--- a/examples/evaluate_st.py
+++ b/examples/evaluate_st.py
@@ -1,12 +1,12 @@
 import mteb
 from sentence_transformers import SentenceTransformer
 
-model_name = "ModernBERT/bert24-base-v2-2ep-decay_100B-0.08-lr"
+model_name = "answerdotai/ModernBERT-base"
 lr = 8e-5
 model_shortname = model_name.split("/")[-1]
 run_name = f"{model_shortname}-DPR-{lr}"
 output_dir = f"output/{model_shortname}/{run_name}"
-model = SentenceTransformer(f"{output_dir}/final", trust_remote_code=True)
+model = SentenceTransformer(f"{output_dir}/final")
 
 task_names = ["SciFact", "NFCorpus", "FiQA2018", "TRECCOVID"]
 tasks = mteb.get_tasks(tasks=[task_names])

--- a/examples/train_pylate.py
+++ b/examples/train_pylate.py
@@ -5,69 +5,73 @@ from sentence_transformers import (
     SentenceTransformerTrainingArguments,
 )
 
-# Load the datasets required for knowledge distillation (train, queries, documents)
-train = load_dataset(
-    path="lightonai/ms-marco-en-bge",
-    name="train",
-)
+def main():
+    # Load the datasets required for knowledge distillation (train, queries, documents)
+    train = load_dataset(
+        path="lightonai/ms-marco-en-bge",
+        name="train",
+    )
 
-queries = load_dataset(
-    path="lightonai/ms-marco-en-bge",
-    name="queries",
-)
+    queries = load_dataset(
+        path="lightonai/ms-marco-en-bge",
+        name="queries",
+    )
 
-documents = load_dataset(
-    path="lightonai/ms-marco-en-bge",
-    name="documents",
-)
+    documents = load_dataset(
+        path="lightonai/ms-marco-en-bge",
+        name="documents",
+    )
 
-# Set the transformation to load the documents/queries texts using the corresponding ids on the fly
-train.set_transform(
-    utils.KDProcessing(queries=queries, documents=documents).transform,
-)
+    # Set the transformation to load the documents/queries texts using the corresponding ids on the fly
+    train.set_transform(
+        utils.KDProcessing(queries=queries, documents=documents).transform,
+    )
 
-# Define the base model, training parameters, and output directory
-num_train_epochs = 1
-lr = 8e-5
-batch_size = 16
-accum_steps = 1
-model_name = "ModernBERT/bert24-base-v2-2ep-decay_100B-0.08-lr"
-model_shortname = model_name.split("/")[-1]
+    # Define the base model, training parameters, and output directory
+    num_train_epochs = 1
+    lr = 8e-5
+    batch_size = 16
+    accum_steps = 1
+    model_name = "answerdotai/ModernBERT-base"
+    model_shortname = model_name.split("/")[-1]
 
-# Set the run name for logging and output directory
-run_name = f"{model_shortname}-colbert-KD-{lr}"
-output_dir = f"output/{model_shortname}/{run_name}"
+    # Set the run name for logging and output directory
+    run_name = f"{model_shortname}-colbert-KD-{lr}"
+    output_dir = f"output/{model_shortname}/{run_name}"
 
-# Initialize the ColBERT model from the base model
-model = models.ColBERT(model_name_or_path=model_name, trust_remote_code=True)
+    # Initialize the ColBERT model from the base model
+    model = models.ColBERT(model_name_or_path=model_name)
 
-# Configure the training arguments (e.g., epochs, batch size, learning rate)
-args = SentenceTransformerTrainingArguments(
-    output_dir=output_dir,
-    num_train_epochs=num_train_epochs,
-    per_device_train_batch_size=batch_size,
-    fp16=False,  # Set to False if you get an error that your GPU can't run on FP16
-    bf16=True,  # Set to True if you have a GPU that supports BF16
-    run_name=run_name,
-    logging_steps=10,
-    learning_rate=lr,
-    gradient_accumulation_steps=accum_steps,
-    warmup_ratio=0.05,
-)
+    # Configure the training arguments (e.g., epochs, batch size, learning rate)
+    args = SentenceTransformerTrainingArguments(
+        output_dir=output_dir,
+        num_train_epochs=num_train_epochs,
+        per_device_train_batch_size=batch_size,
+        fp16=False,  # Set to False if you get an error that your GPU can't run on FP16
+        bf16=True,  # Set to True if you have a GPU that supports BF16
+        run_name=run_name,
+        logging_steps=10,
+        learning_rate=lr,
+        gradient_accumulation_steps=accum_steps,
+        warmup_ratio=0.05,
+    )
 
-# Use the Distillation loss function for training
-train_loss = losses.Distillation(model=model)
+    # Use the Distillation loss function for training
+    train_loss = losses.Distillation(model=model)
 
-# Initialize the trainer
-trainer = SentenceTransformerTrainer(
-    model=model,
-    args=args,
-    train_dataset=train,
-    loss=train_loss,
-    data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
-)
+    # Initialize the trainer
+    trainer = SentenceTransformerTrainer(
+        model=model,
+        args=args,
+        train_dataset=train,
+        loss=train_loss,
+        data_collator=utils.ColBERTCollator(tokenize_fn=model.tokenize),
+    )
 
-# Start the training process
-trainer.train()
+    # Start the training process
+    trainer.train()
 
-model.save_pretrained(f"{output_dir}/final")
+    model.save_pretrained(f"{output_dir}/final")
+
+if __name__ == "__main__":
+    main()

--- a/examples/train_st.py
+++ b/examples/train_st.py
@@ -10,74 +10,82 @@ from sentence_transformers.evaluation import TripletEvaluator
 from sentence_transformers.losses import CachedMultipleNegativesRankingLoss
 from sentence_transformers.training_args import BatchSamplers
 
-# parse the lr
-parser = argparse.ArgumentParser()
-parser.add_argument("--lr", type=float, default=8e-5)
-parser.add_argument("--model_name", type=str, default="ModernBERT/bert24-base-v2-2ep-decay_100B-0.08-lr")
-args = parser.parse_args()
-lr = args.lr
-model_name = args.model_name
-model_shortname = model_name.split("/")[-1]
+def main():
+    # parse the lr & model name
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lr", type=float, default=8e-5)
+    parser.add_argument("--model_name", type=str, default="answerdotai/ModernBERT-base")
+    args = parser.parse_args()
+    lr = args.lr
+    model_name = args.model_name
+    model_shortname = model_name.split("/")[-1]
 
-# 1. Load a model to finetune
-model = SentenceTransformer(model_name, trust_remote_code=True)
+    # 1. Load a model to finetune
+    model = SentenceTransformer(model_name)
 
-# 2. Load a dataset to finetune on
-dataset = load_dataset("sentence-transformers/msmarco-co-condenser-margin-mse-sym-mnrl-mean-v1", "triplet-hard")
-dataset_dict = dataset.train_test_split(test_size=1_000, seed=12)
-train_dataset = dataset_dict["train"].select(range(1_250_000))
-eval_dataset = dataset_dict["test"]
+    # 2. Load a dataset to finetune on
+    dataset = load_dataset(
+        "sentence-transformers/msmarco-co-condenser-margin-mse-sym-mnrl-mean-v1",
+        "triplet-hard",
+        split="train",
+    )
+    dataset_dict = dataset.train_test_split(test_size=1_000, seed=12)
+    train_dataset = dataset_dict["train"].select(range(1_250_000))
+    eval_dataset = dataset_dict["test"]
 
-# 3. Define a loss function
-loss = CachedMultipleNegativesRankingLoss(model, mini_batch_size=16)  # Increase mini_batch_size if you have enough VRAM
+    # 3. Define a loss function
+    loss = CachedMultipleNegativesRankingLoss(model, mini_batch_size=16)  # Increase mini_batch_size if you have enough VRAM
 
-run_name = f"{model_shortname}-DPR-{lr}"
-# 4. (Optional) Specify training arguments
-args = SentenceTransformerTrainingArguments(
-    # Required parameter:
-    output_dir=f"output/{model_shortname}/{run_name}",
-    # Optional training parameters:
-    num_train_epochs=1,
-    per_device_train_batch_size=512,
-    per_device_eval_batch_size=512,
-    warmup_ratio=0.05,
-    fp16=False,  # Set to False if GPU can't handle FP16
-    bf16=True,  # Set to True if GPU supports BF16
-    batch_sampler=BatchSamplers.NO_DUPLICATES,  # (Cached)MultipleNegativesRankingLoss benefits from no duplicates
-    learning_rate=lr,
-    # Optional tracking/debugging parameters:
-    save_strategy="steps",
-    save_steps=500,
-    save_total_limit=2,
-    logging_steps=500,
-    run_name=run_name,  # Used in `wandb`, `tensorboard`, `neptune`, etc. if installed
-)
+    run_name = f"{model_shortname}-DPR-{lr}"
+    # 4. (Optional) Specify training arguments
+    args = SentenceTransformerTrainingArguments(
+        # Required parameter:
+        output_dir=f"output/{model_shortname}/{run_name}",
+        # Optional training parameters:
+        num_train_epochs=1,
+        per_device_train_batch_size=512,
+        per_device_eval_batch_size=512,
+        warmup_ratio=0.05,
+        fp16=False,  # Set to False if GPU can't handle FP16
+        bf16=True,  # Set to True if GPU supports BF16
+        batch_sampler=BatchSamplers.NO_DUPLICATES,  # (Cached)MultipleNegativesRankingLoss benefits from no duplicates
+        learning_rate=lr,
+        # Optional tracking/debugging parameters:
+        save_strategy="steps",
+        save_steps=500,
+        save_total_limit=2,
+        logging_steps=500,
+        run_name=run_name,  # Used in `wandb`, `tensorboard`, `neptune`, etc. if installed
+    )
 
-# 5. (Optional) Create an evaluator & evaluate the base model
-dev_evaluator = TripletEvaluator(
-    anchors=eval_dataset["query"],
-    positives=eval_dataset["positive"],
-    negatives=eval_dataset["negative"],
-    name="msmarco-co-condenser-dev",
-)
-dev_evaluator(model)
+    # 5. (Optional) Create an evaluator & evaluate the base model
+    dev_evaluator = TripletEvaluator(
+        anchors=eval_dataset["query"],
+        positives=eval_dataset["positive"],
+        negatives=eval_dataset["negative"],
+        name="msmarco-co-condenser-dev",
+    )
+    dev_evaluator(model)
 
-# 6. Create a trainer & train
-trainer = SentenceTransformerTrainer(
-    model=model,
-    args=args,
-    train_dataset=train_dataset,
-    eval_dataset=eval_dataset,
-    loss=loss,
-    evaluator=dev_evaluator,
-)
-trainer.train()
+    # 6. Create a trainer & train
+    trainer = SentenceTransformerTrainer(
+        model=model,
+        args=args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        loss=loss,
+        evaluator=dev_evaluator,
+    )
+    trainer.train()
 
-# 7. (Optional) Evaluate the trained model on the evaluator after training
-dev_evaluator(model)
+    # 7. (Optional) Evaluate the trained model on the evaluator after training
+    dev_evaluator(model)
 
-# 8. Save the model
-model.save_pretrained(f"output/{model_shortname}/{run_name}/final")
+    # 8. Save the model
+    model.save_pretrained(f"output/{model_shortname}/{run_name}/final")
 
-# 9. (Optional) Push it to the Hugging Face Hub
-model.push_to_hub(run_name, private=False)
+    # 9. (Optional) Push it to the Hugging Face Hub
+    model.push_to_hub(run_name, private=False)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
remove trust_remote_code, fix split="train" in train_st.py

cc @NohTow could you review & merge this, and then merge `retrieval_boilerplates` into `main`? If that's done, we can start linking to it in the Transformers PR.

- Tom Aarsen
