### PR TITLE
[`examples`] Add 'model.max_seq_length = 8192' because ST accidentally sets it to 512

### DIFF
--- a/examples/train_st.py
+++ b/examples/train_st.py
@@ -25,6 +25,7 @@ def main():
 
     # 1. Load a model to finetune
     model = SentenceTransformer(model_name)
+    model.max_seq_length = 8192
 
     # 2. Load a dataset to finetune on
     dataset = load_dataset(

--- a/examples/train_st_gooaq.py
+++ b/examples/train_st_gooaq.py
@@ -25,6 +25,7 @@ def main():
 
     # 1. Load a model to finetune
     model = SentenceTransformer(model_name)
+    model.max_seq_length = 8192
 
     # 2. Load a dataset to finetune on
     dataset = load_dataset("sentence-transformers/gooaq", split="train")


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add 'model.max_seq_length = 8192' because ST accidentally sets it to 512

## Details
ST automatically sets it to 512 based on 'max_position_embeddings'. Ideally either ST or Transformers makes some changes to avoid this, but for now this is a bit of a workaround.

- Tom Aarsen