### PR TITLE
Remove hardcoded temporary quick fix for missing tokens in pretraining data

### DIFF
--- a/src/text_data.py
+++ b/src/text_data.py
@@ -500,11 +500,6 @@ class NoStreamingDataset(Dataset):
         if "input_ids" in sample:
             for k in list(sample.keys()):
                 if isinstance(sample[k], np.ndarray):
-                    if sample[k][0] != 50281:
-                        sample[k] = np.insert(sample[k], 0, 50281)[: self.max_seq_len]
-                    if sample[k][-1] != 50282:
-                        sample[k] = sample[k][: self.max_seq_len - 1]
-                        sample[k] = np.append(sample[k], 50282)
                     sample[k] = sample[k][: self.max_seq_len]
                 else:
                     del sample[k]


### PR DESCRIPTION
This PR reverts the hardcoded data duct tape we used during pretraining to not have to reformat all data.

When all our training on the malformatted data with missing tokens has been done, we should remove the hardcoded fix as it will create issues for others using our repo.

See my issue #177 