### PR TITLE
Update dependency: use correct mosaicml-streaming package

### DIFF
--- a/requirements-data.txt
+++ b/requirements-data.txt
@@ -4,4 +4,4 @@ huggingface_hub==0.23.1
 pyyaml
 ruff
 tqdm
-streaming
+mosaicml-streaming


### PR DESCRIPTION
This PR changes the installation name of `streaming` in `requirements-data.txt` to `mosaicml-streaming`, referencing the [streaming package developed by MosaicML](https://docs.mosaicml.com/projects/streaming/en/stable/index.html) originally intended for use by ModernBERT on the data side.

This fixes installation issues, and any imports of `streaming` will now correctly instruct users to use MosaicML's package.

Fixes #185