### PR TITLE
Fix: Use default_factory for splits and make char fields optional in DatasetConstants

### DIFF
--- a/src/convert_dataset.py
+++ b/src/convert_dataset.py
@@ -7,7 +7,7 @@ import os
 import platform
 import warnings
 from argparse import ArgumentParser, Namespace
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Iterable, Optional, Union
 
@@ -72,9 +72,9 @@ class DataSplitConstants:
 
 @dataclass
 class DatasetConstants:
-    chars_per_sample: int
-    chars_per_token: int
-    splits = {}
+    chars_per_sample: Optional[int] = None
+    chars_per_token: Optional[int] = None
+    splits: dict[str, DataSplitConstants] = field(default_factory=dict)
 
     def __iter__(self):
         for _, v in self.splits.items():


### PR DESCRIPTION
In my opinion, many users will utilize this script to experiment with their own datasets for training. However, the original DatasetConstants class had two main issues:

1. The 'splits' attribute was declared as a class variable, causing it to be shared among all instances. This could lead to unexpected side effects.
2. The char fields (chars_per_sample and chars_per_token) were required, which could be inconvenient for some executions.


**Changes**

- Updated the 'splits' attribute to use `field(default_factory=dict)`, ensuring each DatasetConstants instance gets its own independent dictionary.
- Changed the type hints for `chars_per_sample` and `chars_per_token` to Optional[int] with default values of None, making these parameters optional and the script more flexible.


This change is essential to avoid potential time waste for users who might otherwise encounter unexpected behavior when running the script on their own datasets.